### PR TITLE
Added support for .NET Core

### DIFF
--- a/AsyncIO.Tests.Stub/AsyncIO.Tests.Stub.csproj
+++ b/AsyncIO.Tests.Stub/AsyncIO.Tests.Stub.csproj
@@ -4,13 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{86F9D0C2-E016-41D5-913B-22A0B2C965D9}</ProjectGuid>
+    <ProjectGuid>{AFBE5D0D-B2BA-4249-80BA-986233F76FD8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AsyncIO</RootNamespace>
     <AssemblyName>AsyncIO</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,13 +45,18 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="FileSystem\AsyncFile.cs" />
-    <Compile Include="FileSystem\PathValidator.cs" />
+    <Compile Include="..\AsyncIO\FileSystem\AsyncFile.cs">
+      <Link>AsyncFile.cs</Link>
+    </Compile>
+    <Compile Include="..\AsyncIO\FileSystem\PathValidator.cs">
+      <Link>PathValidator.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AsyncIO.Tests.Stub/Properties/AssemblyInfo.cs
+++ b/AsyncIO.Tests.Stub/Properties/AssemblyInfo.cs
@@ -5,23 +5,22 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("AsyncIO")]
+[assembly: AssemblyTitle("AsyncIO.TestVersion")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("AsyncIO")]
+[assembly: AssemblyProduct("AsyncIO.TestVersion")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("AsyncIO.Tests")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("86f9d0c2-e016-41d5-913b-22a0b2c965d9")]
+[assembly: Guid("afbe5d0d-b2ba-4249-80ba-986233f76fd8")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/AsyncIO.Tests.Stub/packages.config
+++ b/AsyncIO.Tests.Stub/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net452" />
+</packages>

--- a/AsyncIO.Tests.Stub/packages.config
+++ b/AsyncIO.Tests.Stub/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net452" />
+  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" />
 </packages>

--- a/AsyncIO.Tests/AsyncIO.Tests.csproj
+++ b/AsyncIO.Tests/AsyncIO.Tests.csproj
@@ -55,9 +55,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AsyncIO\AsyncIO.csproj">
-      <Project>{86F9D0C2-E016-41D5-913B-22A0B2C965D9}</Project>
-      <Name>AsyncIO</Name>
+    <ProjectReference Include="..\AsyncIO.Tests.Stub\AsyncIO.Tests.Stub.csproj">
+      <Project>{afbe5d0d-b2ba-4249-80ba-986233f76fd8}</Project>
+      <Name>AsyncIO.Tests.Stub</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>

--- a/AsyncIO.sln
+++ b/AsyncIO.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncIO", "AsyncIO\AsyncIO.csproj", "{86F9D0C2-E016-41D5-913B-22A0B2C965D9}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncIO.Tests", "AsyncIO.Tests\AsyncIO.Tests.csproj", "{3ECCCCB2-ADC9-4909-BA3C-5306D5A87C15}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AsyncIO", "AsyncIO\AsyncIO.xproj", "{25A9084E-0995-4ED7-8097-AD16C143B4C6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncIO.Tests.Stub", "AsyncIO.Tests.Stub\AsyncIO.Tests.Stub.csproj", "{AFBE5D0D-B2BA-4249-80BA-986233F76FD8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +15,18 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{86F9D0C2-E016-41D5-913B-22A0B2C965D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{86F9D0C2-E016-41D5-913B-22A0B2C965D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{86F9D0C2-E016-41D5-913B-22A0B2C965D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{86F9D0C2-E016-41D5-913B-22A0B2C965D9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3ECCCCB2-ADC9-4909-BA3C-5306D5A87C15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3ECCCCB2-ADC9-4909-BA3C-5306D5A87C15}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3ECCCCB2-ADC9-4909-BA3C-5306D5A87C15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3ECCCCB2-ADC9-4909-BA3C-5306D5A87C15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25A9084E-0995-4ED7-8097-AD16C143B4C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25A9084E-0995-4ED7-8097-AD16C143B4C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25A9084E-0995-4ED7-8097-AD16C143B4C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25A9084E-0995-4ED7-8097-AD16C143B4C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFBE5D0D-B2BA-4249-80BA-986233F76FD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFBE5D0D-B2BA-4249-80BA-986233F76FD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFBE5D0D-B2BA-4249-80BA-986233F76FD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFBE5D0D-B2BA-4249-80BA-986233F76FD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AsyncIO/AsyncIO.xproj
+++ b/AsyncIO/AsyncIO.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>25a9084e-0995-4ed7-8097-ad16c143b4c6</ProjectGuid>
+    <RootNamespace>AsyncIO</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/AsyncIO/FileSystem/AsyncFile.cs
+++ b/AsyncIO/FileSystem/AsyncFile.cs
@@ -4,9 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-#if !DNXCORE50
 using JetBrains.Annotations;
-#endif
 
 namespace AsyncIO.FileSystem
 {
@@ -29,11 +27,7 @@ namespace AsyncIO.FileSystem
             return AppendAllLinesAsync(path, contents, Encoding.UTF8, cancellationToken);
         }
 
-#if DNXCORE50
-        public static async Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
-#else
         public static async Task AppendAllLinesAsync(string path, [NotNull] IEnumerable<string> contents, [NotNull] Encoding encoding, CancellationToken cancellationToken)
-#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));
@@ -64,11 +58,7 @@ namespace AsyncIO.FileSystem
             return AppendAllTextAsync(path, contents, Encoding.UTF8);
         }
 
-#if DNXCORE50
-        public static async Task AppendAllTextAsync(string path, string contents, Encoding encoding)
-#else
         public static async Task AppendAllTextAsync(string path, [NotNull] string contents, [NotNull] Encoding encoding)
-#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));
@@ -156,10 +146,8 @@ namespace AsyncIO.FileSystem
             PathValidator.EnsureCorrectFileSystemPath(sourceFileName);
             PathValidator.EnsureCorrectFileSystemPath(destFileName);
 
-#if !DNXCORE50
-            if (Path.GetFullPath(sourceFileName) == Path.GetFullPath(destFileName))
+            if (Path.Combine(Path.GetDirectoryName(sourceFileName), sourceFileName) == Path.Combine(Path.GetDirectoryName(destFileName), destFileName))
                 return;
-#endif
             const int fileBufferSize = 4096;
             using (var sourceStream = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read, fileBufferSize, true))
             {
@@ -220,11 +208,7 @@ namespace AsyncIO.FileSystem
             return ReadAllLinesAsync(path, Encoding.UTF8, cancellationToken);
         }
 
-#if DNXCORE50
-        public static async Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken)
-#else
         public static async Task<string[]> ReadAllLinesAsync([NotNull] string path, [NotNull] Encoding encoding, CancellationToken cancellationToken)
-#endif
         {
             if (encoding == null)
                 throw new ArgumentNullException(nameof(encoding));
@@ -312,11 +296,7 @@ namespace AsyncIO.FileSystem
 
         }
 
-#if DNXCORE50
-        public static async Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
-#else
         public static async Task WriteAllLinesAsync(string path, [NotNull] IEnumerable<string> contents, [NotNull] Encoding encoding, CancellationToken cancellationToken)
-#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));
@@ -347,11 +327,7 @@ namespace AsyncIO.FileSystem
             return WriteAllTextAsync(path, contents, Encoding.UTF8);
         }
 
-#if DNXCORE50
-        public static async Task WriteAllTextAsync(string path, string contents, Encoding encoding)
-#else
         public static async Task WriteAllTextAsync(string path, [NotNull] string contents, [NotNull] Encoding encoding)
-#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));

--- a/AsyncIO/FileSystem/AsyncFile.cs
+++ b/AsyncIO/FileSystem/AsyncFile.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+#if !DNXCORE50
 using JetBrains.Annotations;
+#endif
 
 namespace AsyncIO.FileSystem
 {
@@ -27,7 +29,11 @@ namespace AsyncIO.FileSystem
             return AppendAllLinesAsync(path, contents, Encoding.UTF8, cancellationToken);
         }
 
+#if DNXCORE50
+        public static async Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
+#else
         public static async Task AppendAllLinesAsync(string path, [NotNull] IEnumerable<string> contents, [NotNull] Encoding encoding, CancellationToken cancellationToken)
+#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));
@@ -58,7 +64,11 @@ namespace AsyncIO.FileSystem
             return AppendAllTextAsync(path, contents, Encoding.UTF8);
         }
 
+#if DNXCORE50
+        public static async Task AppendAllTextAsync(string path, string contents, Encoding encoding)
+#else
         public static async Task AppendAllTextAsync(string path, [NotNull] string contents, [NotNull] Encoding encoding)
+#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));
@@ -146,8 +156,10 @@ namespace AsyncIO.FileSystem
             PathValidator.EnsureCorrectFileSystemPath(sourceFileName);
             PathValidator.EnsureCorrectFileSystemPath(destFileName);
 
+#if !DNXCORE50
             if (Path.GetFullPath(sourceFileName) == Path.GetFullPath(destFileName))
                 return;
+#endif
             const int fileBufferSize = 4096;
             using (var sourceStream = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read, fileBufferSize, true))
             {
@@ -208,7 +220,11 @@ namespace AsyncIO.FileSystem
             return ReadAllLinesAsync(path, Encoding.UTF8, cancellationToken);
         }
 
+#if DNXCORE50
+        public static async Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken)
+#else
         public static async Task<string[]> ReadAllLinesAsync([NotNull] string path, [NotNull] Encoding encoding, CancellationToken cancellationToken)
+#endif
         {
             if (encoding == null)
                 throw new ArgumentNullException(nameof(encoding));
@@ -296,7 +312,11 @@ namespace AsyncIO.FileSystem
 
         }
 
+#if DNXCORE50
+        public static async Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
+#else
         public static async Task WriteAllLinesAsync(string path, [NotNull] IEnumerable<string> contents, [NotNull] Encoding encoding, CancellationToken cancellationToken)
+#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));
@@ -327,7 +347,11 @@ namespace AsyncIO.FileSystem
             return WriteAllTextAsync(path, contents, Encoding.UTF8);
         }
 
+#if DNXCORE50
+        public static async Task WriteAllTextAsync(string path, string contents, Encoding encoding)
+#else
         public static async Task WriteAllTextAsync(string path, [NotNull] string contents, [NotNull] Encoding encoding)
+#endif
         {
             if (contents == null)
                 throw new ArgumentNullException(nameof(contents));

--- a/AsyncIO/packages.config
+++ b/AsyncIO/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net45" />
-</packages>

--- a/AsyncIO/project.json
+++ b/AsyncIO/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "version": "1.0.0.0",
-  "description": "AsyncIO",
+  "description": "Common asynchronous operations with file system.\nAppendAllLinesAsync\nAppendAllTextAsync\nCopyAsync\nDeleteAsync\nMoveAsync\nReadAllBytesAsync\nReadAllLinesAsync\nReadAllTextAsync\nWriteAllBytesAsync\nWriteAllLinesAsync\nWriteAllTextAsync",
   "authors": [ "Mykhailo Matviiv"],
   "tags": [ "io asynchronous async core .net file files directory" ],
   "projectUrl": "https://github.com/FireNero/AsyncIO",

--- a/AsyncIO/project.json
+++ b/AsyncIO/project.json
@@ -1,0 +1,47 @@
+﻿{
+  "version": "1.0.0.0",
+  "description": "AsyncIO",
+  "authors": [ "Mykhailo Matviiv"],
+  "tags": [ "io asynchronous async core .net file files directory" ],
+  "projectUrl": "https://github.com/FireNero/AsyncIO",
+  "licenseUrl": "https://github.com/FireNero/AsyncIO/blob/master/LICENSE",
+
+  "configurations": {
+    "Debug": {
+      "compilationOptions": {
+        "define": [ "DEBUG", "TRACE" ]
+      }
+    },
+    "Release": {
+      "compilationOptions": {
+        "define": [ "RELEASE", "TRACE" ],
+        "optimize": true
+      }
+    }
+  },
+
+  "code": [ "**/*.cs" ],
+
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "JetBrains.Annotations": "10.0.0"
+      }
+    },
+    "net451": {
+      "dependencies": {
+        "JetBrains.Annotations": "10.0.0"
+      }
+    },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Threading": "4.0.0.0",
+        "System.Threading.Tasks": "4.0.0.0",
+        "System.Linq": "4.0.0.0",
+        "System.IO.FileSystem": "4.0.0"
+      }
+    }
+  }
+}

--- a/AsyncIO/project.json
+++ b/AsyncIO/project.json
@@ -37,10 +37,9 @@
       "dependencies": {
         "System.Runtime": "4.0.20",
         "System.Runtime.Extensions": "4.0.0",
-        "System.Threading": "4.0.0.0",
-        "System.Threading.Tasks": "4.0.0.0",
         "System.Linq": "4.0.0.0",
-        "System.IO.FileSystem": "4.0.0"
+        "System.IO.FileSystem": "4.0.0",
+        "JetBrains.Annotations": "10.1.1-eap"
       }
     }
   }


### PR DESCRIPTION
Moved to a Class Library (Package) project type.
Add support for .NET Core using compiler directives.
Created a stub library with rerefences to existing code files,  for testing, since it is not possible to reference the .xproj project directly from Tests project.
Output nuget packages for publishing will be located in the SolutionDir/artifacts
